### PR TITLE
feat: Add cop checking that enable_updates is not switched on globally

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
        matrix:
-         ruby-version: [2.6.8, 2.7.4, 3.0.2]
+         ruby-version: [2.6.8, 2.7.4, 3.0.4, 3.1.3, 3.2.1]
     steps:
     - uses: actions/checkout@v2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-linux
 

--- a/lib/rubocop/cop/cable_ready/application_record_enable_updates.rb
+++ b/lib/rubocop/cop/cable_ready/application_record_enable_updates.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module CableReady
+      class ApplicationRecordEnableUpdates < Base
+        MSG = "enable_updates should not be switched on globally"
+
+        def_node_search :active_record_base_class?, <<~PATTERN
+          (const (const nil? :ActiveRecord) :Base)
+        PATTERN
+
+        def_node_matcher :is_application_record?, <<~PATTERN
+          (const nil? :ApplicationRecord)
+        PATTERN
+
+        def on_send(node)
+          receiver_node, _method_name, *_arg_nodes = *node.parent.parent
+
+          return if node.method_name != :enable_updates
+
+          return unless is_application_record?(receiver_node)
+
+          return unless node.ancestors.any? { |ancestor| active_record_base_class?(ancestor) }
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/cable_ready/application_record_enable_updates.rb
+++ b/lib/rubocop/cop/cable_ready/application_record_enable_updates.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module CableReady
       class ApplicationRecordEnableUpdates < Base
-        MSG = "enable_updates should not be switched on globally"
+        MSG = "%<method_name>s should not be switched on globally"
 
         def_node_search :active_record_base_class?, <<~PATTERN
           (const (const nil? :ActiveRecord) :Base)
@@ -17,13 +17,14 @@ module RuboCop
         def on_send(node)
           receiver_node, _method_name, *_arg_nodes = *node.parent.parent
 
-          return if node.method_name != :enable_updates
+          return unless %i[enable_updates enable_cable_ready_updates].include?(node.method_name)
 
           return unless is_application_record?(receiver_node)
 
           return unless node.ancestors.any? { |ancestor| active_record_base_class?(ancestor) }
 
-          add_offense(node)
+          message = format(MSG, method_name: node.method_name)
+          add_offense(node, message: message)
         end
       end
     end

--- a/lib/rubocop/cop/cable_ready_cops.rb
+++ b/lib/rubocop/cop/cable_ready_cops.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
+require_relative "cable_ready/application_record_enable_updates"
 require_relative "cable_ready/broadcaster_controller_action"
 require_relative "cable_ready/unused_cable_ready_call"

--- a/spec/rubocop/cop/cable_ready/application_record_enable_updates_spec.rb
+++ b/spec/rubocop/cop/cable_ready/application_record_enable_updates_spec.rb
@@ -3,6 +3,17 @@
 require "spec_helper"
 
 RSpec.describe RuboCop::Cop::CableReady::ApplicationRecordEnableUpdates, :config do
+  it "registers an offense for the global ApplicationRecord model calling the enable_cable_ready_updates class method" do
+    expect_offense(<<~RUBY)
+      class ApplicationRecord < ActiveRecord::Base
+        include CableReady::Updatable
+
+        enable_cable_ready_updates on: :update
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enable_cable_ready_updates should not be switched on globally
+      end
+    RUBY
+  end
+
   it "registers an offense for the global ApplicationRecord model calling the enable_updates class method" do
     expect_offense(<<~RUBY)
       class ApplicationRecord < ActiveRecord::Base
@@ -10,6 +21,16 @@ RSpec.describe RuboCop::Cop::CableReady::ApplicationRecordEnableUpdates, :config
 
         enable_updates on: :update
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ enable_updates should not be switched on globally
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for any other model calling the enable_cable_ready_updates class method" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < ActiveRecord::Base
+        include CableReady::Updatable
+
+        enable_cable_ready_updates on: :update
       end
     RUBY
   end

--- a/spec/rubocop/cop/cable_ready/application_record_enable_updates_spec.rb
+++ b/spec/rubocop/cop/cable_ready/application_record_enable_updates_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RuboCop::Cop::CableReady::ApplicationRecordEnableUpdates, :config do
+  it "registers an offense for the global ApplicationRecord model calling the enable_updates class method" do
+    expect_offense(<<~RUBY)
+      class ApplicationRecord < ActiveRecord::Base
+        include CableReady::Updatable
+
+        enable_updates on: :update
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ enable_updates should not be switched on globally
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for any other model calling the enable_updates class method" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < ActiveRecord::Base
+        include CableReady::Updatable
+
+        enable_updates on: :update
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/cable_ready/application_record_enable_updates_spec.rb
+++ b/spec/rubocop/cop/cable_ready/application_record_enable_updates_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe RuboCop::Cop::CableReady::ApplicationRecordEnableUpdates, :config do
-  it "registers an offense for the global ApplicationRecord model calling the enable_cable_ready_updates class method" do
+  it "registers an offense for the global ApplicationRecord model calling the enable_cable_ready_updates class method" do # rubocop:disable Layout/LineLength
     expect_offense(<<~RUBY)
       class ApplicationRecord < ActiveRecord::Base
         include CableReady::Updatable


### PR DESCRIPTION
**bad**
```ruby
class ApplicationRecord < ActiveRecord::Base
  include CableReady::Updatable

  enable_cable_ready_updates on: :update
  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enable_cable_ready_updates should not be switched on globally
end
```

**good**
```ruby
class Post < ActiveRecord::Base
  include CableReady::Updatable
  
  enable_cable_ready_updates on: :update
end
```


